### PR TITLE
Refresh weekly schedule, footer year, and add freshness disclaimer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 bun.lockb
+bun.lock
 package-lock.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+The official site for 阪大言語サークルGGC (Osaka University language circle). Japanese single-page site plus a blog.
+
+## Commands
+
+Package manager is **Bun** (`engine-strict=true` is set; do not use npm/yarn/pnpm).
+
+- `bun install` — install deps
+- `bun dev` (or `bun dev --open`) — Vite dev server
+- `bun run build` — production build (Cloudflare Pages output)
+- `bun run preview` — preview the built site
+- `bun run check` — `svelte-kit sync` + `svelte-check` type/diagnostic pass; use `check:watch` for watch mode
+- `bun run lint` — Prettier check + ESLint
+- `bun run format` — Prettier write
+
+No test suite exists in this repo.
+
+## Architecture
+
+**Stack:** SvelteKit 1.x (Svelte 4) + TypeScript, Vite, deployed to Cloudflare Pages via `@sveltejs/adapter-cloudflare`. Icons via `unplugin-icons` (svelte compiler) — import from `~icons/...`.
+
+**Path aliases** (defined in `svelte.config.js`, on top of the default `$lib`):
+- `$assets` → `src/assets`
+- `$data` → `src/data`
+
+**Single-page structure.** `src/routes/+page.svelte` is the home page. The page's content is driven entirely by the `SECTIONS` array in `src/lib/sections/index.ts` — each entry pairs an `id` (used as the anchor link target), a Japanese `name` (shown in nav), and a Svelte `component`. The nav menu, hamburger menu, and main content all iterate over this same array, so adding/removing a section means editing only that file plus creating the section component under `src/lib/sections/`.
+
+**Blog → Newt CMS.** `src/lib/api/newt.ts` exports a `NewtClient` singleton (`client`) plus the `Post`/`Author`/`Tag` content types. It is a vendored/modified port of `newt-client-js`. Two private env vars are required (`$env/static/private`):
+- `PRIVATE_NEWT_SPACE_UID`
+- `PRIVATE_NEWT_CDN_TOKEN`
+
+The blog data flow is:
+- `src/routes/blog/+page.server.ts` — list page, calls `client.getContents<Post>({ appUid: 'blog', modelUid: 'article' })`
+- `src/routes/blog/[slug]/+page.server.ts` — article page, uses `getFirstContent` with a `slug` query
+- `src/routes/api/blog/+server.ts` — JSON endpoint mirroring the list
+
+Without the env vars set, blog routes and the API endpoint will throw on load. All Newt fetches go through `fetchWithRetry` in `src/lib/util/fetch.ts` (3 retries, only retries 429/500).
+
+**Static data lives in `src/data/`:**
+- `sns.json` — SNS account list, typed via the `SNSAccount`/`SNS` declarations in `src/app.d.ts` and `src/lib/util/sns.ts`
+- `languages.ts` — `LANGUAGE_NAMES_JA` and `LANGUAGES` maps; `Lang` is derived as `keyof typeof LANGUAGE_NAMES_JA` and used as the canonical language type elsewhere
+
+## Code style
+
+Prettier config (`.prettierrc`): tabs, single quotes, no trailing commas, 100 col width. ESLint extends `@typescript-eslint/recommended` + `plugin:svelte/recommended`. TypeScript is `strict: true` with `checkJs` enabled.

--- a/src/lib/sections/Footer.svelte
+++ b/src/lib/sections/Footer.svelte
@@ -4,7 +4,7 @@
 
 <footer>
 	<p>
-		<RiCopyrightLine /> 2022-2023 阪大言語サークルGGC
+		<RiCopyrightLine /> 2022-2026 阪大言語サークルGGC
 	</p>
 </footer>
 

--- a/src/lib/sections/SectionContent.svelte
+++ b/src/lib/sections/SectionContent.svelte
@@ -30,62 +30,52 @@
 			<th>夜</th>
 			<td>
 				<CalenderEvent
-					name="言語類型論"
-					place="520@箕面"
-					href="#minoh"
-					time="18:30–20:15"
-					color="r"
-					detail="集まった人たちで、自分の話せる言語や勉強している言語について教えあいます。"
+					name="初級アイスランド語"
+					place="SSB@豊中"
+					href="#tynkb"
+					time="18:30–19:50"
+					color="b"
+					detail="みんなで同じ言語を学びます。"
 				/>
 			</td>
 			<td>
 				<CalenderEvent
-					name="アラビア語"
+					name="初級ジョージア語"
+					place="SSB@豊中"
+					href="#tynkb"
+					time="18:30–19:50"
+					color="b"
+					detail="みんなで同じ言語を学びます。"
+				/>
+			</td>
+			<td>
+				<CalenderEvent
+					name="ナウル語"
 					place="520@箕面"
 					href="#minoh"
-					time="18:30–20:15"
+					time="18:30–20:10"
 					color="r"
 					detail="みんなで同じ言語を学びます。"
 				/>
 			</td>
 			<td>
 				<CalenderEvent
-					name="スウェーデン語"
-					place="520@箕面"
-					href="#minoh"
-					time="18:30–20:15"
-					color="r"
+					name="綴りと発音が一致しているという幻想"
+					place="SSB@豊中"
+					href="#tynkb"
+					time="18:30–19:50"
+					color="b"
 					detail="部員が語学や言語学にまつわることについて教えあいます。"
 				/>
 			</td>
 			<td>
-				<!-- 
 				<CalenderEvent
-					name="個別発表・参加型"
+					name="ワードル（ゲーム）"
 					place="SSB@豊中"
 					href="#tynkb"
-					time="18:00–19:45"
+					time="18:30–19:50"
 					color="b"
-					detail="部員が語学や言語学にまつわることについて教えあいます。そのほか参加型の企画を行うこともあります。"
-				/>
-				-->
-			</td>
-			<td>
-				<CalenderEvent
-					name="インドネシア語"
-					place="SSB@豊中"
-					href="#tynkb"
-					time="18:00–19:45"
-					color="b"
-					detail="夜にはみんなでラテン語など古典語を勉強しています。"
-				/>
-				<CalenderEvent
-					name="ロマンス語（ラテン語含）"
-					place="SSB@豊中"
-					href="#tynkb"
-					time="18:00–19:45"
-					color="b"
-					detail="夜にはみんなでラテン語など古典語を勉強しています。"
+					detail="ことばに関するゲームをみんなで楽しみます。"
 				/>
 			</td>
 		</tr>

--- a/src/lib/sections/SectionContent.svelte
+++ b/src/lib/sections/SectionContent.svelte
@@ -82,6 +82,9 @@
 	</tbody>
 </table>
 <p class="notice">※いずれも変更の可能性あり</p>
+<p class="notice">
+	※当ホームページの情報は参考用であり、頻繁には更新されません。実際にご参加の際は、Instagram・LINEオープンチャット等のSNSもあわせてご確認のうえ、最新情報をご確認ください。
+</p>
 
 <a
 	href="https://sites.google.com/view/ggccalendar/%E3%83%9B%E3%83%BC%E3%83%A0"


### PR DESCRIPTION
## Summary
- Update the 活動内容 weekday table to the 5/21–5/27 Information poster (初級アイスランド語 / 初級ジョージア語 / ナウル語 / 綴りと発音が一致しているという幻想 / ワードル). Adjusted times to 箕面 18:30–20:10 and 豊中 18:30–19:50.
- Bump footer copyright from `2022-2023` to `2022-2026`.
- Add a notice below the schedule explaining that the site is for reference and isn't updated frequently, asking visitors to cross-check Instagram, the LINE OpenChat, and other SNS before attending.
- Housekeeping: add `CLAUDE.md` and ignore the new text-format `bun.lock`.

## Test plan
- [ ] `bun install`
- [ ] `bun dev` and visually confirm the 活動内容 table shows the new Mon–Fri events with the right locations/times and the new notice
- [ ] Confirm the footer reads `2022-2026`
- [ ] (optional) Cloudflare Pages preview deploy from this branch looks good before merging to `main`


---
_Generated by [Claude Code](https://claude.ai/code/session_01RGeP7Q9cZNE2mN8S8jxfyH)_