### PR TITLE
Add YouTube section with latest videos from @oulcggc

### DIFF
--- a/src/data/youtube.ts
+++ b/src/data/youtube.ts
@@ -1,0 +1,9 @@
+export const YOUTUBE_HANDLE = 'oulcggc';
+export const YOUTUBE_CHANNEL_URL = `https://www.youtube.com/@${YOUTUBE_HANDLE}`;
+
+export type Video = {
+	id: string;
+	title: string;
+	publishedAt: string;
+	channelTitle: string;
+};

--- a/src/lib/api/youtube.ts
+++ b/src/lib/api/youtube.ts
@@ -1,0 +1,76 @@
+import { YOUTUBE_CHANNEL_URL, type Video } from '$data/youtube';
+
+let cachedChannelId: string | null = null;
+
+const CHANNEL_ID_PATTERNS = [
+	/"channelId":"(UC[A-Za-z0-9_-]{22})"/,
+	/"externalId":"(UC[A-Za-z0-9_-]{22})"/,
+	/channel\/(UC[A-Za-z0-9_-]{22})/
+];
+
+async function resolveChannelId(): Promise<string> {
+	if (cachedChannelId) return cachedChannelId;
+
+	const res = await fetch(YOUTUBE_CHANNEL_URL, {
+		headers: {
+			'user-agent': 'Mozilla/5.0 (compatible; ggc-site/1.0; +https://ggc-osaka.pages.dev/)',
+			'accept-language': 'ja,en;q=0.8'
+		}
+	});
+	if (!res.ok) throw new Error(`Failed to load channel page (${res.status})`);
+
+	const html = await res.text();
+	for (const pattern of CHANNEL_ID_PATTERNS) {
+		const match = html.match(pattern);
+		if (match) {
+			cachedChannelId = match[1];
+			return cachedChannelId;
+		}
+	}
+	throw new Error('Could not extract channel ID from channel page');
+}
+
+function unescapeXml(s: string): string {
+	return s
+		.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&quot;/g, '"')
+		.replace(/&apos;/g, "'")
+		.replace(/&#39;/g, "'")
+		.replace(/&amp;/g, '&');
+}
+
+export async function getLatestVideos(limit = 6): Promise<Video[]> {
+	const channelId = await resolveChannelId();
+	const rssUrl = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
+
+	const res = await fetch(rssUrl);
+	if (!res.ok) throw new Error(`Failed to load channel feed (${res.status})`);
+	const xml = await res.text();
+
+	const videos: Video[] = [];
+	const entryRegex = /<entry>([\s\S]*?)<\/entry>/g;
+	let m: RegExpExecArray | null;
+	while ((m = entryRegex.exec(xml)) !== null) {
+		const entry = m[1];
+		const id = entry.match(/<yt:videoId>([^<]+)<\/yt:videoId>/)?.[1];
+		const title = entry.match(/<title>([\s\S]*?)<\/title>/)?.[1];
+		const publishedAt = entry.match(/<published>([^<]+)<\/published>/)?.[1];
+		const channelTitle = entry.match(
+			/<author>[\s\S]*?<name>([^<]+)<\/name>[\s\S]*?<\/author>/
+		)?.[1];
+
+		if (id && title && publishedAt) {
+			videos.push({
+				id,
+				title: unescapeXml(title).trim(),
+				publishedAt,
+				channelTitle: channelTitle ? unescapeXml(channelTitle).trim() : ''
+			});
+			if (videos.length >= limit) break;
+		}
+	}
+
+	return videos;
+}

--- a/src/lib/sections/SectionYouTube.svelte
+++ b/src/lib/sections/SectionYouTube.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import LiteYouTube from '$lib/ui/LiteYouTube.svelte';
+	import YouTubeCardSkeleton from '$lib/ui/YouTubeCardSkeleton.svelte';
+	import { YOUTUBE_CHANNEL_URL, type Video } from '$data/youtube';
+	import RiYoutubeFill from '~icons/ri/youtube-fill';
+
+	async function fetchVideos(): Promise<Video[]> {
+		const res = await fetch('/api/youtube');
+		if (!res.ok) throw new Error('Failed to load videos');
+		const data = (await res.json()) as { items: Video[] };
+		return data.items;
+	}
+
+	const dateFmt = new Intl.DateTimeFormat('ja-JP', {
+		dateStyle: 'long',
+		timeZone: 'Asia/Tokyo'
+	});
+</script>
+
+<h2>YouTube</h2>
+<h3>最新の動画</h3>
+
+<div class="grid">
+	{#await fetchVideos()}
+		{#each Array(3) as _}
+			<YouTubeCardSkeleton />
+		{/each}
+	{:then videos}
+		{#if videos.length === 0}
+			<p class="empty">まだ動画がありません。</p>
+		{:else}
+			{#each videos as video}
+				<article class="card">
+					<LiteYouTube videoId={video.id} title={video.title} />
+					<h4>
+						<a
+							class="text title-link"
+							href={`https://www.youtube.com/watch?v=${video.id}`}
+							target="_blank"
+							rel="noopener"
+						>
+							{video.title}
+						</a>
+					</h4>
+					<time datetime={video.publishedAt}>
+						{dateFmt.format(new Date(video.publishedAt))}
+					</time>
+				</article>
+			{/each}
+		{/if}
+	{:catch}
+		<p class="error">動画を取得できませんでした。後ほどお試しください。</p>
+	{/await}
+</div>
+
+<a class="text channel-link" href={YOUTUBE_CHANNEL_URL} target="_blank" rel="noopener">
+	<RiYoutubeFill height="1.5em" />
+	チャンネルを開く
+</a>
+
+<style>
+	h2 {
+		text-align: center;
+	}
+
+	.grid {
+		display: grid;
+		gap: 1.75em;
+		grid-template-columns: repeat(auto-fit, minmax(18em, 1fr));
+		width: 100%;
+		max-width: 60em;
+		margin: 0 auto;
+	}
+
+	.card {
+		display: grid;
+		gap: 0.5em;
+		align-content: start;
+	}
+
+	.card h4 {
+		margin: 0;
+		font-size: 1em;
+		line-height: 1.45;
+		color: var(--color-theme);
+	}
+
+	.title-link {
+		color: inherit;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	time {
+		color: #666;
+		font-size: 0.85em;
+	}
+
+	.empty,
+	.error {
+		grid-column: 1 / -1;
+		color: #888;
+		text-align: center;
+	}
+
+	.channel-link {
+		font-weight: bold;
+		margin-top: 1em;
+	}
+</style>

--- a/src/lib/sections/index.ts
+++ b/src/lib/sections/index.ts
@@ -3,6 +3,7 @@ import SectionPlace from '$lib/sections/SectionPlace.svelte';
 import SectionContact from '$lib/sections/SectionContact.svelte';
 import SectionHome from '$lib/sections/SectionHome.svelte';
 import SectionAbout from '$lib/sections/SectionAbout.svelte';
+import SectionYouTube from '$lib/sections/SectionYouTube.svelte';
 import SectionBlog from './SectionBlog.svelte';
 
 export type Section = {
@@ -21,6 +22,11 @@ export const SECTIONS = [
 		name: 'ブログ',
 		id: 'blog',
 		component: SectionBlog
+	},
+	{
+		name: '動画',
+		id: 'videos',
+		component: SectionYouTube
 	},
 	{
 		name: 'サークル紹介',

--- a/src/lib/ui/LiteYouTube.svelte
+++ b/src/lib/ui/LiteYouTube.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+	export let videoId: string;
+	export let title: string;
+
+	let activated = false;
+
+	function activate() {
+		activated = true;
+	}
+
+	$: thumbUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+	$: embedUrl = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`;
+</script>
+
+<div class="lite-yt" class:activated>
+	{#if activated}
+		<iframe
+			src={embedUrl}
+			{title}
+			frameborder="0"
+			allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+			referrerpolicy="strict-origin-when-cross-origin"
+			allowfullscreen
+		/>
+	{:else}
+		<button type="button" class="play" aria-label={`動画を再生: ${title}`} on:click={activate}>
+			<img src={thumbUrl} alt="" loading="lazy" decoding="async" />
+			<span class="badge" aria-hidden="true">
+				<svg viewBox="0 0 68 48">
+					<path
+						class="badge-bg"
+						d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55C3.97 2.33 2.27 4.81 1.48 7.74 0 13.05 0 24 0 24s0 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C68 34.95 68 24 68 24s0-10.95-1.48-16.26z"
+					/>
+					<path d="M45 24 27 14v20z" fill="#fff" />
+				</svg>
+			</span>
+		</button>
+	{/if}
+</div>
+
+<style>
+	.lite-yt {
+		position: relative;
+		width: 100%;
+		aspect-ratio: 16 / 9;
+		background: #000;
+		border-radius: 0.5em;
+		overflow: hidden;
+		box-shadow: 0 4px 18px rgba(24, 65, 100, 0.08);
+	}
+
+	.play {
+		display: block;
+		width: 100%;
+		height: 100%;
+		padding: 0;
+		border: none;
+		background: none;
+		cursor: pointer;
+		position: relative;
+	}
+
+	.play img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+		transition: transform 0.45s ease;
+	}
+
+	.play:hover img,
+	.play:focus-visible img {
+		transform: scale(1.04);
+	}
+
+	.badge {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		width: 4.5em;
+		transform: translate(-50%, -50%);
+		filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.45));
+		transition: transform 0.25s ease;
+	}
+
+	.badge svg {
+		width: 100%;
+		height: auto;
+		display: block;
+	}
+
+	.badge-bg {
+		fill: #212121;
+		opacity: 0.85;
+		transition: fill 0.2s ease, opacity 0.2s ease;
+	}
+
+	.play:hover .badge,
+	.play:focus-visible .badge {
+		transform: translate(-50%, -50%) scale(1.08);
+	}
+
+	.play:hover .badge-bg,
+	.play:focus-visible .badge-bg {
+		fill: #ff0000;
+		opacity: 1;
+	}
+
+	iframe {
+		width: 100%;
+		height: 100%;
+		border: 0;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.play img,
+		.badge,
+		.badge-bg {
+			transition: none;
+		}
+	}
+</style>

--- a/src/lib/ui/YouTubeCardSkeleton.svelte
+++ b/src/lib/ui/YouTubeCardSkeleton.svelte
@@ -1,0 +1,50 @@
+<div class="skeleton" aria-hidden="true">
+	<div class="thumb" />
+	<div class="line" />
+	<div class="line short" />
+</div>
+
+<style>
+	.skeleton {
+		display: grid;
+		gap: 0.6em;
+	}
+
+	.thumb,
+	.line {
+		background: linear-gradient(90deg, #eee 25%, #f5f5f5 50%, #eee 75%);
+		background-size: 200% 100%;
+		animation: shimmer 1.4s ease-in-out infinite;
+		border-radius: 0.4em;
+	}
+
+	.thumb {
+		width: 100%;
+		aspect-ratio: 16 / 9;
+		border-radius: 0.5em;
+	}
+
+	.line {
+		height: 0.9em;
+	}
+
+	.line.short {
+		width: 55%;
+	}
+
+	@keyframes shimmer {
+		0% {
+			background-position: 200% 0;
+		}
+		100% {
+			background-position: -200% 0;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.thumb,
+		.line {
+			animation: none;
+		}
+	}
+</style>

--- a/src/routes/api/youtube/+server.ts
+++ b/src/routes/api/youtube/+server.ts
@@ -1,0 +1,15 @@
+import { error, json } from '@sveltejs/kit';
+import { getLatestVideos } from '$lib/api/youtube';
+
+export const GET = async ({ setHeaders }): Promise<Response> => {
+	try {
+		const items = await getLatestVideos(6);
+		setHeaders({
+			'cache-control': 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400'
+		});
+		return json({ items });
+	} catch (e) {
+		console.error(e);
+		throw error(500, 'Unable to fetch YouTube videos');
+	}
+};


### PR DESCRIPTION
## Summary
- New top-level **動画** section between ブログ and サークル紹介 showing the latest videos from the channel.
- Server endpoint `GET /api/youtube` resolves the `@oulcggc` channel ID from the channel page once (cached in module memory), then loads the public Atom feed at `https://www.youtube.com/feeds/videos.xml?channel_id=...`. **No YouTube Data API key required.** The endpoint response sets `cache-control: public, s-maxage=3600, stale-while-revalidate=86400` so Cloudflare's edge effectively caches it for an hour.
- `LiteYouTube.svelte` shows the YouTube thumbnail with a YouTube-style play button; only injects the iframe **on click**, and uses `youtube-nocookie.com` so we don't set YouTube tracking cookies for visitors who never play a video.
- `YouTubeCardSkeleton.svelte` provides a shimmering placeholder, mirroring the blog card skeleton pattern.
- Honors `prefers-reduced-motion`.

## Files
- `src/data/youtube.ts` — handle constant, channel URL, `Video` type
- `src/lib/api/youtube.ts` — channel-ID resolver + RSS parser (server-side only)
- `src/routes/api/youtube/+server.ts` — JSON endpoint mirroring `/api/blog`
- `src/lib/ui/LiteYouTube.svelte` — thumbnail → iframe on click
- `src/lib/ui/YouTubeCardSkeleton.svelte` — loading placeholder
- `src/lib/sections/SectionYouTube.svelte` — the new section
- `src/lib/sections/index.ts` — register section in nav

## Test plan
- [ ] `bun install && bun dev`, scroll to the **動画** section, confirm three skeleton cards appear briefly then resolve to the latest videos from `@oulcggc` with thumbnails, titles (clamped to two lines), and dates in JST
- [ ] Click a thumbnail — confirm the iframe replaces the thumbnail in place and the video autoplays; no YouTube cookies are set until that click
- [ ] Resize down — confirm the grid reflows to a single column under ~18em
- [ ] Toggle "Reduce motion" in OS — confirm no shimmer/hover transitions
- [ ] Hit `/api/youtube` directly in a browser — confirm JSON `{ items: [...] }` and a `cache-control` response header
- [ ] First request after deploy may be a bit slower (channel ID resolution + RSS fetch); subsequent requests within the hour should be edge-cached


---
_Generated by [Claude Code](https://claude.ai/code/session_01RGeP7Q9cZNE2mN8S8jxfyH)_