### PR TITLE
Use firstPublishedAt for blog post dates (fixes #6)

### DIFF
--- a/src/lib/ui/blog/BlogCard.svelte
+++ b/src/lib/ui/blog/BlogCard.svelte
@@ -31,7 +31,8 @@
 			numeric: 'auto'
 		}).format(
 			Math.round(
-				(new Date(article._sys.updatedAt).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)
+				(new Date(article._sys.raw.firstPublishedAt).getTime() - new Date().getTime()) /
+					(1000 * 60 * 60 * 24)
 			),
 			'day'
 		)}

--- a/src/lib/ui/blog/BlogResult.svelte
+++ b/src/lib/ui/blog/BlogResult.svelte
@@ -19,7 +19,7 @@
 				dateStyle: 'long',
 				timeStyle: 'short',
 				timeZone: 'Asia/Tokyo'
-			}).format(new Date(article._sys.updatedAt))}</span
+			}).format(new Date(article._sys.raw.firstPublishedAt))}</span
 		>
 	</div>
 	<div class="tags">

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -41,7 +41,7 @@
 				dateStyle: 'long',
 				timeStyle: 'short',
 				timeZone: 'Asia/Tokyo'
-			}).format(new Date(article._sys.updatedAt))}</span
+			}).format(new Date(article._sys.raw.firstPublishedAt))}</span
 		>
 		<!-- <span>{data.publishedAt}</span> -->
 	</div>


### PR DESCRIPTION
Fixes #6.

## Problem
Blog dates were sourced from `_sys.updatedAt`, which Newt overwrites every time an article is republished. Briefly unpublishing an old article and re-publishing it made it appear as a brand-new post on the list, in the home-page teaser, and in the article header.

## Fix
Switch all three display sites to `_sys.raw.firstPublishedAt`, which Newt sets once at the article's original publish time and never overwrites:

- `src/lib/ui/blog/BlogCard.svelte` — home-page "X 日前" relative-time badge
- `src/lib/ui/blog/BlogResult.svelte` — blog list date column
- `src/routes/blog/[slug]/+page.svelte` — article header date

(The issue comment mentioned `article._sys.firstPublishedAt`, but per the `Content` type in `src/lib/api/newt.ts` the field actually lives at `_sys.raw.firstPublishedAt` — `_sys.firstPublishedAt` is not part of the schema.)

## Test plan
- [ ] On a deploy with Newt configured, confirm the list, home-page card, and article-header date all match the **original** publish date for an article that's been republished after a temporary unpublish.
- [ ] `bun run check` clean ✓ (verified locally — 0 errors).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RGeP7Q9cZNE2mN8S8jxfyH)_